### PR TITLE
filter out libxc 3.x dep variants in test_dep_versions_per_toolchain_generation

### DIFF
--- a/test/easyconfigs/easyconfigs.py
+++ b/test/easyconfigs/easyconfigs.py
@@ -213,6 +213,13 @@ class EasyConfigTest(TestCase):
                     if re.search('; versionsuffix: .*-CUDA-[0-9.]+', key):
                         dep_vars.pop(key)
 
+            # some software packages require an old version of libxc
+            if dep == 'libxc' and len(dep_vars) > 1:
+                for key in dep_vars.keys():
+                    # CP2K & ABINIT require libxc 3.x, so filter it out
+                    if re.search('^version: 3\.', key):
+                        dep_vars.pop(key)
+
             # only single variant is always OK
             if len(dep_vars) == 1:
                 res = True


### PR DESCRIPTION
@migueldiascosta This should fix the broken test in https://github.com/easybuilders/easybuild-easyconfigs/pull/6587 (verification is being done in https://travis-ci.org/boegel/easybuild-easyconfigs/builds/413547604).