### PR TITLE
add patch for R 3.6.2 with intel/2019b to fix compilation on CentOS 8

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.6.2-intel-2019b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.6.2-intel-2019b.eb
@@ -9,12 +9,10 @@ toolchain = {'name': 'intel', 'version': '2019b'}
 
 source_urls = ['https://cloud.r-project.org/src/base/R-%(version_major)s']
 sources = [SOURCE_TAR_GZ]
-patches = [
-    '%(name)s-%(version)s_fix_long_dbl_on_ppc.patch',
-]
+patches = ['%(name)s-%(version)s_fix-intel-recent-glibc.patch']
 checksums = [
     'bd65a45cddfb88f37370fbcee4ac8dd3f1aebeebe47c2f968fd9770ba2bbc954',  # R-3.6.2.tar.gz
-    '833b80f9a62751eae9cfbad6116542acf932e9c6511235145be32264aacdce69',  # R-3.6.2_fix_long_dbl_on_ppc.patch
+    '1052d223df58b6199edbac3721640f06b22a282c95dd0db982566dc36884a146',  # R-3.6.2_fix-intel-recent-glibc.patch
 ]
 
 builddependencies = [

--- a/easybuild/easyconfigs/r/R/R-3.6.2_fix-intel-recent-glibc.patch
+++ b/easybuild/easyconfigs/r/R/R-3.6.2_fix-intel-recent-glibc.patch
@@ -1,0 +1,55 @@
+Fix for compilation error on OS with recent glibc when using Intel compilers:
+
+arithmetic.c(61): warning #274: declaration is not visible outside of function
+  int matherr(struct exception *exc)
+                     ^
+
+arithmetic.c(63): error: pointer to incomplete class type is not allowed
+      switch (exc->type) {
+              ^
+
+The R configure script only checks for the existence of the matherr function,
+and assumes the exception struct is also defined when matherr is defined by glibc's math.h .
+That is no longer the case in recent glibc versions, where the exception struct is no longer defined.
+
+author: Kenneth Hoste (HPC-UGent)
+
+See also:
+* https://community.intel.com/t5/Intel-C-Compiler/Error-when-compiling-R-from-source-code-ubuntu-18-04/td-p/1176401
+* https://stat.ethz.ch/pipermail/r-help/2020-May/466997.html
+--- R-3.6.2/configure.orig	2020-09-18 09:25:26.171766714 +0200
++++ R-3.6.2/configure	2020-09-18 09:38:59.035921459 +0200
+@@ -35539,6 +35539,15 @@
+ done
+ 
+ 
++# check for exception struct in math.h
++ac_fn_c_check_member "$LINENO" "struct exception" "type" "ac_cv_member_struct_exception_type" "#include <math.h>"
++if test "x$ac_cv_member_struct_exception_type" = xyes; then :
++cat >>confdefs.h <<_ACEOF
++#define HAVE_STRUCT_EXCEPTION 1
++_ACEOF
++fi
++
++
+ ## POSIX functions
+ for ac_func in fcntl
+ do
+--- R-3.6.2/src/main/arithmetic.c.orig	2020-09-18 09:24:17.969082474 +0200
++++ R-3.6.2/src/main/arithmetic.c	2020-09-18 09:39:53.736470218 +0200
+@@ -53,6 +53,7 @@
+ #include <errno.h>
+ 
+ #ifdef HAVE_MATHERR
++#ifdef HAVE_STRUCT_EXCEPTION
+ 
+ /* Override the SVID matherr function:
+    the main difference here is not to print warnings.
+@@ -81,6 +82,7 @@
+ }
+ #endif
+ #endif
++#endif
+ 
+ typedef union
+ {


### PR DESCRIPTION
for https://github.com/easybuilders/easybuild-easyconfigs/pull/11298

Tested on both CentOS 7 and 8, works as intended.

On CentOS 7, the `config.log` shows:

```
checking for struct exception.type... yes
```

on CentOS 8:

```
checking for struct exception.type... no
```